### PR TITLE
Add support for all routing kernels to ESX and Penalty

### DIFF
--- a/include/arlib/esx.hpp
+++ b/include/arlib/esx.hpp
@@ -97,142 +97,19 @@ template <typename Graph, typename WeightMap, typename MultiPredecessorMap,
 void esx(const Graph &G, WeightMap const &weight,
          MultiPredecessorMap &predecessors, Vertex s, Vertex t, int k,
          double theta, routing_kernels algorithm = routing_kernels::astar) {
-  using namespace boost;
-  using Edge = typename graph_traits<Graph>::edge_descriptor;
-  using Length = typename boost::property_traits<WeightMap>::value_type;
-
-  BOOST_CONCEPT_ASSERT((VertexAndEdgeListGraphConcept<Graph>));
-  BOOST_CONCEPT_ASSERT((LvaluePropertyMapConcept<WeightMap, Edge>));
-
-  // P_LO set of k paths
-  auto resPathsEdges = std::vector<std::vector<Edge>>{};
-  auto resEdges = std::vector<std::unordered_set<Edge, boost::hash<Edge>>>{};
-
-  BOOST_CONCEPT_ASSERT((VertexAndEdgeListGraphConcept<Graph>));
-  BOOST_CONCEPT_ASSERT((LvaluePropertyMapConcept<WeightMap, Edge>));
-
-  // P_LO set of k paths
-  auto resPaths = std::vector<Path<Graph>>{};
-  // Compute shortest path from s to t
-  auto [sp_path, sp_len] = details::compute_shortest_path(G, weight, s, t);
-
-  // P_LO <-- {shortest path p_0(s, t)};
-  resPathsEdges.push_back(sp_path);
-  resEdges.emplace_back(sp_path.begin(), sp_path.end());
-
-  // If we need the shortest path only
-  if (k == 1) {
-    details::fill_multi_predecessor(resPathsEdges.begin(), resPathsEdges.end(),
-                                    G, predecessors);
-    return;
-  }
-
-  // Every max-heap H_i is associated with p_i
-  using Priority = std::pair<Edge, int>;
-  using EdgePriorityQueue =
-      std::priority_queue<Priority, std::vector<Priority>,
-                          details::EdgePriorityComparator<Edge>>;
-  auto edge_priorities = std::vector<EdgePriorityQueue>(k);
-
-  // We keep a set of non-removable edges
-  auto dnr_edges = std::unordered_set<Edge, boost::hash<Edge>>{};
-
-  // We keep a set of deleted-edges
+  using Edge = edge_of_t<Graph>;
+  using Length = length_of_t<Graph>;
   auto deleted_edges = std::unordered_set<Edge, boost::hash<Edge>>{};
-
-  // Compute lower bounds for AStar
-  auto heuristic = details::distance_heuristic<Graph, Length>(G, t);
-
-  // Make shortest path algorithm function
-  auto compute_shortest_path = details::build_shortest_path_fn(
-      algorithm, G, s, t, heuristic, deleted_edges);
-
-  // Initialize max-heap H_0 with the priority of each edge of the shortest path
-  details::init_edge_priorities(sp_path, edge_priorities, 0, G, deleted_edges);
-
-  auto overlaps = std::vector<double>(k, 0.0);
-  overlaps[0] = 1.0; // Set p_c overlap with sp (itself) to 1
-
-  bool still_feasible = true;
-  while (resPathsEdges.size() < static_cast<std::size_t>(k) && still_feasible) {
-    std::ptrdiff_t p_max_idx = 0;
-    double overlap_ratio = 1.0;
-
-    while (overlap_ratio >= theta) {
-      // Get the max overlapping path
-      auto max_it = std::max_element(std::begin(overlaps), std::end(overlaps));
-      p_max_idx = max_it - std::begin(overlaps);
-      overlap_ratio = *max_it;
-
-      // Check if finding a result is feasible
-      still_feasible = details::check_feasibility(overlaps);
-      if (!still_feasible) {
-        break; // Stop the algorithm
-      }
-
-      // Get e_tmp with higher priority from H_{p_max_idx}
-      auto e_tmp = edge_priorities[p_max_idx].top().first;
-
-      // If edge is in DO-NOT-REMOVE edges set, continue
-      if (dnr_edges.find(e_tmp) != std::end(dnr_edges)) {
-        edge_priorities[p_max_idx].pop();
-        // Also, if H_{p_max_idx} queue is empty set its overlapping value to 0
-        if (edge_priorities[p_max_idx].empty()) {
-          overlaps[p_max_idx] = 0;
-        }
-        continue;
-      } else {
-        // Otherwise, add e_tmp to deleted edges
-        deleted_edges.insert(e_tmp);
-      }
-
-      // Compute p_tmp shortest path
-      auto p_tmp = compute_shortest_path(G, s, t, heuristic, deleted_edges);
-
-      // If shortest path did not find a path
-      if (!p_tmp) {
-        details::move_to_dnr(e_tmp, deleted_edges, dnr_edges);
-        continue;
-      }
-
-      // Remove e_tmp from H_{p_max_idx}
-      edge_priorities[p_max_idx].pop();
-
-      // in cases there are no more edges to remove we set overlap to zero to
-      // avoid choosing from the same path again. A path the overlap of which is
-      // zero can never be chosen to remove its edges.
-      if (edge_priorities[p_max_idx].empty()) {
-        overlaps[p_max_idx] = 0;
-      } else {
-        const auto &alt_path = resEdges[p_max_idx];
-        overlaps[p_max_idx] =
-            details::compute_similarity(*p_tmp, alt_path, weight);
-      }
-
-      // Checking if the resulting path is valid
-      bool candidate_is_valid =
-          details::check_candidate_validity(*p_tmp, resEdges, weight, theta);
-      if (candidate_is_valid) {
-        // Add p_tmp to P_LO
-        resPathsEdges.emplace_back(*p_tmp);
-        resEdges.emplace_back(p_tmp->begin(), p_tmp->end());
-
-        // Set p_c overlap with itself to 1
-        std::ptrdiff_t p_c_idx = resPathsEdges.size() - 1;
-        overlaps[p_c_idx] = 1.0;
-
-        // Initialize max-heap H_i with the priority of each edge of new
-        // alternative path
-        details::init_edge_priorities(*p_tmp, edge_priorities, p_c_idx, G,
-                                      deleted_edges);
-        break; // From inner while loop
-      }
-    }
+  if (algorithm == routing_kernels::astar) {
+    auto heuristic = details::distance_heuristic<Graph, Length>(G, t);
+    auto routing_kernel = details::build_shortest_path_fn(
+        algorithm, G, s, t, weight, heuristic, deleted_edges);
+    details::esx(G, weight, predecessors, s, t, k, theta, routing_kernel);
+  } else {
+    auto routing_kernel = details::build_shortest_path_fn(
+        algorithm, G, s, t, weight, deleted_edges);
+    details::esx(G, weight, predecessors, s, t, k, theta, routing_kernel);
   }
-
-  // Beforer returning, populate predecessors map
-  details::fill_multi_predecessor(resPathsEdges.begin(), resPathsEdges.end(), G,
-                                  predecessors);
 }
 
 /**

--- a/test/include/test_esx.cpp
+++ b/test/include/test_esx.cpp
@@ -56,21 +56,21 @@ TEST_CASE("Edge priority computation", "[esx]") {
   REQUIRE(contains(sp_path.begin(), sp_path.end(), edge(0, 3, G).first));
   auto s_n3 = edge(0, 3, G).first;
 
-  int prio_s_n3 = compute_priority(G, s_n3, deleted_edges);
+  int prio_s_n3 = compute_priority(G, s_n3, weight_map, deleted_edges);
   REQUIRE(prio_s_n3 == 0);
 
   // Check that (3, 5) was computed in shortest path
   REQUIRE(contains(sp_path.begin(), sp_path.end(), edge(3, 5, G).first));
   auto n3_n5 = edge(3, 5, G).first;
 
-  int prio_n3_n5 = compute_priority(G, n3_n5, deleted_edges);
+  int prio_n3_n5 = compute_priority(G, n3_n5, weight_map, deleted_edges);
   REQUIRE(prio_n3_n5 == 3);
 
   // Check that (5, 6) was computed in shortest path
   REQUIRE(contains(sp_path.begin(), sp_path.end(), edge(5, 6, G).first));
   auto n5_t = edge(5, 6, G).first;
 
-  int prio_n5_t = compute_priority(G, n5_t, deleted_edges);
+  int prio_n5_t = compute_priority(G, n5_t, weight_map, deleted_edges);
   REQUIRE(prio_n5_t == 0);
 }
 
@@ -142,6 +142,32 @@ TEST_CASE("ESX running with bidirectional dijkstra returns same result as "
   auto predecessors_bi = arlib::multi_predecessor_map<Vertex>{};
   arlib::esx(G, predecessors_bi, s, t, 3, 0.5,
              arlib::routing_kernels::bidirectional_dijkstra);
+  auto res_paths_bi = arlib::to_paths(G, predecessors_bi, s, t);
+
+  REQUIRE(res_paths_uni.size() == res_paths_bi.size());
+
+  for (std::size_t i = 0; i < res_paths_uni.size(); ++i) {
+    REQUIRE(res_paths_uni[i].length() == res_paths_bi[i].length());
+  }
+}
+
+TEST_CASE("ESX running with plain dijkstra returns same result as astar",
+          "[esx]") {
+  using namespace boost;
+
+  auto G = arlib::read_graph_from_string<Graph>(std::string(graph_gr_esx));
+
+  Vertex s = 0, t = 6;
+  int k = 3;
+  double theta = 0.5;
+
+  auto predecessors_uni = arlib::multi_predecessor_map<Vertex>{};
+  arlib::esx(G, predecessors_uni, s, t, 3, 0.5);
+  auto res_paths_uni = arlib::to_paths(G, predecessors_uni, s, t);
+
+  auto predecessors_bi = arlib::multi_predecessor_map<Vertex>{};
+  arlib::esx(G, predecessors_bi, s, t, 3, 0.5,
+             arlib::routing_kernels::dijkstra);
   auto res_paths_bi = arlib::to_paths(G, predecessors_bi, s, t);
 
   REQUIRE(res_paths_uni.size() == res_paths_bi.size());

--- a/test/include/test_multi_predecessor_map.cpp
+++ b/test/include/test_multi_predecessor_map.cpp
@@ -30,7 +30,8 @@ TEST_CASE("multi_predecessor_map interface") {
   }
 
   REQUIRE(pred.size() == in_degree(v, G));
-  for (auto [first, last] = in_edges(v, G); first != last; ++first) {
+  graph_traits<Graph>::in_edge_iterator first, last;
+  for (std::tie(first, last) = in_edges(v, G); first != last; ++first) {
     REQUIRE(
         std::find_if(pred.begin(), pred.end(), [&first, &G](auto const &entry) {
           return entry.second == source(*first, G);

--- a/test/include/test_penalty.cpp
+++ b/test/include/test_penalty.cpp
@@ -242,3 +242,35 @@ TEST_CASE("Penalty running with bidirectional dijkstra returns same result as "
     REQUIRE(res_paths_uni[i].length() == res_paths_bi[i].length());
   }
 }
+
+TEST_CASE("Penalty running with astar returns same result as "
+          "unidirectional dijkstra",
+          "[penalty]") {
+  using namespace boost;
+
+  auto G = arlib::read_graph_from_string<Graph>(std::string(graph_gr_esx));
+
+  Vertex s = 0, t = 6;
+  int k = 3;
+  double theta = 0.5;
+  auto p = 0.1;
+  auto r = 0.1;
+  auto bound_limit = 10;
+  auto max_nb_steps = 100000;
+
+  auto predecessors_uni = arlib::multi_predecessor_map<Vertex>{};
+  arlib::penalty(G, predecessors_uni, s, t, k, theta, p, r, bound_limit,
+                 max_nb_steps);
+  auto res_paths_uni = arlib::to_paths(G, predecessors_uni, s, t);
+
+  auto predecessors_bi = arlib::multi_predecessor_map<Vertex>{};
+  arlib::penalty(G, predecessors_bi, s, t, k, theta, p, r, bound_limit,
+                 max_nb_steps, arlib::routing_kernels::astar);
+  auto res_paths_bi = arlib::to_paths(G, predecessors_bi, s, t);
+
+  REQUIRE(res_paths_uni.size() == res_paths_bi.size());
+
+  for (std::size_t i = 0; i < res_paths_uni.size(); ++i) {
+    REQUIRE(res_paths_uni[i].length() == res_paths_bi[i].length());
+  }
+}


### PR DESCRIPTION
Now you can use `dijkstra`, `astar` and `bidirectional_dijkstra` routing kernels both on `ESX` and `OnePass+`