### PR TITLE
Add Terminator classes and support for AR algorithms

### DIFF
--- a/include/arlib/CMakeLists.txt
+++ b/include/arlib/CMakeLists.txt
@@ -12,6 +12,7 @@ set(ARLIB_HEADERS
         include/arlib/path.hpp
         include/arlib/penalty.hpp
         include/arlib/reorder_buffer.hpp
+        include/arlib/terminators.hpp
         include/arlib/type_traits.hpp
         include/arlib/uninformed_bidirectional_pruning.hpp
     PARENT_SCOPE)

--- a/include/arlib/details/arlib_utils.hpp
+++ b/include/arlib/details/arlib_utils.hpp
@@ -39,13 +39,13 @@
 #include <boost/graph/properties.hpp>
 #include <boost/graph/reverse_graph.hpp>
 
-#include <arlib/graph_types.hpp>
-#include <arlib/graph_utils.hpp>
+#include <arlib/path.hpp>
 #include <arlib/type_traits.hpp>
 
 #include <iterator>
 #include <sstream>
 #include <stdexcept>
+#include <unordered_set>
 #include <vector>
 
 namespace arlib {
@@ -269,6 +269,7 @@ template <typename Graph, typename EdgeWeightMap, typename PredecessorMap,
 Path<Graph>
 build_path_from_dijkstra(const Graph &G, EdgeWeightMap const &weight,
                          const PredecessorMap &p, Vertex s, Vertex t) {
+  using boost::edge;
   using Length = typename boost::property_traits<EdgeWeightMap>::value_type;
   using Edge = typename boost::graph_traits<Graph>::edge_descriptor;
 
@@ -282,7 +283,7 @@ build_path_from_dijkstra(const Graph &G, EdgeWeightMap const &weight,
     auto u = p[current];
     path_vs.insert(u);
 
-    auto edge_in_G = boost::edge(u, current, G).first;
+    auto edge_in_G = edge(u, current, G).first;
     length += weight[edge_in_G];
     path_es.insert(edge_in_G);
     current = u;
@@ -313,6 +314,7 @@ template <typename Graph, typename PredecessorMap,
 std::vector<Edge> build_edge_list_from_dijkstra(Graph const &G, Vertex s,
                                                 Vertex t,
                                                 const PredecessorMap &p) {
+  using namespace boost;
   auto edge_list = std::vector<Edge>{};
 
   auto current = t;
@@ -322,7 +324,7 @@ std::vector<Edge> build_edge_list_from_dijkstra(Graph const &G, Vertex s,
       // Vertex 'current' is not reachable from source vertex
       break;
     }
-    auto [e, is_ok] = boost::edge(u, current, G);
+    auto [e, is_ok] = edge(u, current, G);
     assert(is_ok &&
            "[arlib::details::build_edge_list_from_dijkstra] Edge not found.");
     edge_list.push_back(e);

--- a/include/arlib/details/onepass_plus_impl.hpp
+++ b/include/arlib/details/onepass_plus_impl.hpp
@@ -272,19 +272,23 @@ public:
 private:
   template <typename Graph2, typename Length2>
   friend std::ostream &operator<<(std::ostream &os,
-                                  const OnePassLabel<Graph2, Length2> &label) {
-    os << "(node = " << label.node << ", length = " << label.length
-       << ", lower_bound = " << label.lower_bound << ", k = " << label.k
-       << ", checked_at_step = " << label.checked_at_step
-       << ", similarities = [ ";
-    for (auto sim : label.similarity_map) {
-      os << sim << " ";
-    }
-
-    os << "])";
-    return os;
-  }
+                                  const OnePassLabel<Graph2, Length2> &label);
 };
+
+template <typename Graph2, typename Length2>
+std::ostream &operator<<(std::ostream &os,
+                                const OnePassLabel<Graph2, Length2> &label) {
+  os << "(node = " << label.node << ", length = " << label.length
+     << ", lower_bound = " << label.lower_bound << ", k = " << label.k
+     << ", checked_at_step = " << label.checked_at_step
+     << ", similarities = [ ";
+  for (auto sim : label.similarity_map) {
+    os << sim << " ";
+  }
+
+  os << "])";
+  return os;
+}
 
 /**
  * A conventient container for labels dominance checking.

--- a/include/arlib/details/onepass_plus_impl.hpp
+++ b/include/arlib/details/onepass_plus_impl.hpp
@@ -36,7 +36,6 @@
 #include <boost/graph/properties.hpp>
 
 #include <arlib/details/arlib_utils.hpp>
-#include <arlib/graph_types.hpp>
 #include <arlib/type_traits.hpp>
 
 #include <cassert>
@@ -45,6 +44,7 @@
 #include <queue>
 #include <unordered_set>
 #include <vector>
+#include <unordered_map>
 
 namespace arlib {
 /**
@@ -145,13 +145,14 @@ public:
         similarity_map(k, 0), k{k}, checked_at_step{checked_at_step} {}
 
   std::vector<Edge> get_path(Graph const &G) const {
+    using namespace boost;
     auto edge_set = std::vector<Edge>{};
 
     auto v = node;
     auto prev = previous;
     while (prev != nullptr) {
       auto u = prev->node;
-      auto [e, is_ok] = boost::edge(u, v, G);
+      auto [e, is_ok] = edge(u, v, G);
       assert(is_ok &&
              "[arlib::details::OnePassLabel::get_path] Edge not found.");
       edge_set.push_back(e);

--- a/include/arlib/graph_utils.hpp
+++ b/include/arlib/graph_utils.hpp
@@ -53,10 +53,19 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
 
+#include <boost/graph/compressed_sparse_row_graph.hpp>
+
 /**
  * An Alternative-Routing library for Boost.Graph
  */
 namespace arlib {
+using CSRGraph = boost::compressed_sparse_row_graph<
+    boost::bidirectionalS, boost::no_property,
+    boost::property<boost::edge_weight_t, int>>;
+
+CSRGraph read_csr_graph_from_string(const std::string &graph);
+std::optional<CSRGraph> read_csr_graph_from_file(const std::string_view path);
+
 /**
  * Constructs a PropertyGraph from vertices, edges and weights contained in a
  * .gr-format string. An example of .gr-format string is the following:
@@ -108,22 +117,6 @@ PropertyGraph read_graph_from_string(const std::string &graph) {
   return G;
 }
 
-/**
- * Constructs a PropertyGraph from vertices, edges and weights contained in a
- * file in .gr format. An example of .gr-format file is the following:
- * ```
- * d
- * # nb_vertices nb_edges
- * 3 2
- * # v1 v2 weight
- * 0 1 4
- * 1 2 3
- * ```
- *
- * @tparam PropertyGraph The Graph type
- * @param path A .gr-format file path defining the graph.
- * @return the constructed graph.
- */
 template <typename PropertyGraph>
 std::optional<PropertyGraph> read_graph_from_file(const std::string_view path) {
   namespace fs = std::filesystem;

--- a/include/arlib/reorder_buffer.hpp
+++ b/include/arlib/reorder_buffer.hpp
@@ -40,7 +40,8 @@ public:
   template <typename Graph, typename ForwardIt>
   static void by_relative_similarity(Graph const &G, ForwardIt first,
                                      ForwardIt last, long k, double theta) {
-    auto weight = boost::get(boost::edge_weight, G);
+    using namespace boost;
+    auto weight = get(boost::edge_weight, G);
     auto count = 0;
     auto cur = first;
     while (count < k && cur != last) {

--- a/include/arlib/routing_kernels/details/bidirectional_dijkstra_impl.hpp
+++ b/include/arlib/routing_kernels/details/bidirectional_dijkstra_impl.hpp
@@ -44,6 +44,7 @@
 #include <iostream>
 #include <limits>
 #include <queue>
+#include <unordered_map>
 #include <vector>
 
 namespace arlib {

--- a/include/arlib/terminators.hpp
+++ b/include/arlib/terminators.hpp
@@ -24,17 +24,21 @@ public:
 class timer : public terminator<timer> {
 public:
   explicit timer(std::chrono::milliseconds timeout)
+      : timeout_{std::chrono::duration_cast<std::chrono::microseconds>(
+            timeout)},
+        t1_{std::chrono::steady_clock::now()} {}
+  explicit timer(std::chrono::microseconds timeout)
       : timeout_{timeout}, t1_{std::chrono::steady_clock::now()} {}
 
   bool should_stop() const {
     auto t2 = std::chrono::steady_clock::now();
     auto elapsed =
-        std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1_);
+        std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1_);
     return (elapsed > timeout_);
   }
 
 private:
-  std::chrono::milliseconds timeout_;
+  std::chrono::microseconds timeout_;
   std::chrono::time_point<std::chrono::steady_clock> t1_;
 };
 } // namespace arlib

--- a/include/arlib/terminators.hpp
+++ b/include/arlib/terminators.hpp
@@ -1,0 +1,42 @@
+#ifndef ARLIB_ERRORS_H
+#define ARLIB_ERRORS_H
+
+#include <chrono>
+#include <stdexcept>
+
+namespace arlib {
+struct terminator_stop_error : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+template <typename Derived> struct terminator {
+public:
+  bool should_stop() const {
+    return static_cast<Derived &>(*this).should_stop();
+  }
+};
+
+struct always_continue : public terminator<always_continue> {
+public:
+  bool should_stop() const { return false; }
+};
+
+class timer : public terminator<timer> {
+public:
+  explicit timer(std::chrono::milliseconds timeout)
+      : timeout_{timeout}, t1_{std::chrono::steady_clock::now()} {}
+
+  bool should_stop() const {
+    auto t2 = std::chrono::steady_clock::now();
+    auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1_);
+    return (elapsed > timeout_);
+  }
+
+private:
+  std::chrono::milliseconds timeout_;
+  std::chrono::time_point<std::chrono::steady_clock> t1_;
+};
+} // namespace arlib
+
+#endif

--- a/include/arlib/uninformed_bidirectional_pruning.hpp
+++ b/include/arlib/uninformed_bidirectional_pruning.hpp
@@ -38,10 +38,11 @@
 #include <boost/graph/properties.hpp>
 
 #include <arlib/details/arlib_utils.hpp>
-#include <arlib/details/ubp_impl.hpp>
 #include <arlib/routing_kernels/bidirectional_dijkstra.hpp>
 #include <arlib/routing_kernels/visitor.hpp>
 #include <arlib/type_traits.hpp>
+
+#include <arlib/details/ubp_impl.hpp>
 
 #include <limits>
 #include <unordered_set>

--- a/src/arlib/CMakeLists.txt
+++ b/src/arlib/CMakeLists.txt
@@ -1,3 +1,4 @@
 set(ARLIB_SRC
         src/arlib/details/esx_impl.cpp
+        src/arlib/graph_utils.cpp
     PARENT_SCOPE)

--- a/src/arlib/graph_utils.cpp
+++ b/src/arlib/graph_utils.cpp
@@ -1,0 +1,65 @@
+#include <arlib/graph_utils.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string_view>
+#include <vector>
+
+namespace arlib {
+CSRGraph read_csr_graph_from_string(const std::string &graph) {
+  auto ss = std::stringstream{graph};
+  std::string line{};
+
+  // Drop graph type info
+  std::getline(ss, line);
+
+  // Get number of nodes and edges
+  std::getline(ss, line);
+  auto line_s = std::stringstream{line};
+  int nb_nodes, nb_edges;
+  line_s >> nb_nodes >> nb_edges;
+
+  // Get edges and weights
+  auto edges = std::vector<std::pair<int, int>>{};
+  auto weights = std::vector<int>{};
+
+  int s, t, w;
+  while (std::getline(ss, line)) {
+    line_s.str(line);
+    line_s.seekg(std::ios_base::beg);
+    line_s >> s >> t >> w;
+
+    edges.emplace_back(s, t);
+    weights.push_back(w);
+  }
+
+  // Return a CSR Graph from data
+  using VertexSize = boost::graph_traits<CSRGraph>::vertices_size_type;
+  auto G =
+      CSRGraph{boost::edges_are_unsorted_multi_pass, edges.begin(), edges.end(),
+               weights.begin(), static_cast<VertexSize>(nb_nodes)};
+  return G;
+}
+
+std::optional<CSRGraph> read_csr_graph_from_file(const std::string_view path) {
+  namespace fs = std::filesystem;
+  auto fs_path = fs::path(path);
+
+  if (!fs::is_regular_file(fs_path)) {
+    std::cerr << fs_path << " is not a regular file.\n";
+    return {};
+  }
+
+  if (fs::is_empty(fs_path)) {
+    std::cerr << fs_path << " is empty.\n";
+    return {};
+  }
+
+  auto buffer = std::stringstream{};
+  auto input = std::ifstream{fs_path.string()};
+  buffer << input.rdbuf();
+
+  return {read_csr_graph_from_string(buffer.str())};
+}
+} // namespace arlib

--- a/test/include/test_esx.cpp
+++ b/test/include/test_esx.cpp
@@ -196,6 +196,6 @@ TEST_CASE("ESX times-out on large graph", "[esx]") {
 
   REQUIRE_THROWS_AS(arlib::esx(G, predecessors, s, t, k, theta,
                                arlib::routing_kernels::astar,
-                               arlib::timer{1ms}),
+                               arlib::timer{1us}),
                     arlib::terminator_stop_error);
 }

--- a/test/include/test_esx.cpp
+++ b/test/include/test_esx.cpp
@@ -4,22 +4,24 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
 
-#include "test_types.hpp"
-#include "utils.hpp"
-
 #include <arlib/details/arlib_utils.hpp>
 #include <arlib/details/esx_impl.hpp>
 #include <arlib/esx.hpp>
 #include <arlib/graph_utils.hpp>
 #include <arlib/routing_kernels/types.hpp>
+#include <arlib/terminators.hpp>
+
+#include "cittastudi_graph.hpp"
+#include "test_types.hpp"
+#include "utils.hpp"
 
 #include <kspwlo_ref/algorithms/kspwlo.hpp>
 #include <kspwlo_ref/exploration/graph_utils.hpp>
 
+#include <chrono>
 #include <experimental/filesystem>
 #include <memory>
 #include <string>
-
 #include <string_view>
 
 using namespace arlib::test;
@@ -179,4 +181,21 @@ TEST_CASE("ESX running with plain dijkstra returns same result as astar",
   for (std::size_t i = 0; i < res_paths_uni.size(); ++i) {
     REQUIRE(res_paths_uni[i].length() == res_paths_bi[i].length());
   }
+}
+
+TEST_CASE("ESX times-out on large graph", "[esx]") {
+  using namespace boost;
+  using namespace std::chrono_literals;
+
+  auto G = arlib::read_graph_from_string<Graph>(std::string(cittastudi_gr));
+
+  Vertex s = 0, t = 20;
+  auto k = 3;
+  auto theta = 0.5;
+  auto predecessors = arlib::multi_predecessor_map<Vertex>{};
+
+  REQUIRE_THROWS_AS(arlib::esx(G, predecessors, s, t, k, theta,
+                               arlib::routing_kernels::astar,
+                               arlib::timer{1ms}),
+                    arlib::terminator_stop_error);
 }

--- a/test/include/test_onepass_plus.cpp
+++ b/test/include/test_onepass_plus.cpp
@@ -4,13 +4,15 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
 
-#include "test_types.hpp"
-#include "utils.hpp"
-
 #include <arlib/details/onepass_plus_impl.hpp>
 #include <arlib/graph_types.hpp>
 #include <arlib/graph_utils.hpp>
 #include <arlib/onepass_plus.hpp>
+#include <arlib/terminators.hpp>
+
+#include "test_types.hpp"
+#include "utils.hpp"
+#include "cittastudi_graph.hpp"
 
 #include <kspwlo_ref/algorithms/kspwlo.hpp>
 #include <kspwlo_ref/exploration/graph_utils.hpp>
@@ -19,6 +21,7 @@
 #include <experimental/filesystem>
 #include <fstream>
 #include <memory>
+#include <chrono>
 #include <string_view>
 
 using namespace arlib::test;
@@ -137,8 +140,23 @@ TEST_CASE("onepass_plus kspwlo algorithm runs on Boost::Graph",
     REQUIRE(one_regression_path_have_edges(res_regression, p));
   }
 
-  using boost::get;
   using boost::edge_weight;
-  REQUIRE(
-      alternative_paths_are_dissimilar(res, get(edge_weight, G), 0.5));
+  using boost::get;
+  REQUIRE(alternative_paths_are_dissimilar(res, get(edge_weight, G), 0.5));
+}
+
+TEST_CASE("OnePass+ times-out on large graph", "[onepassplus]") {
+  using namespace boost;
+  using namespace std::chrono_literals;
+
+  auto G = arlib::read_graph_from_string<Graph>(std::string(cittastudi_gr));
+
+  Vertex s = 0, t = 20;
+  auto k = 3;
+  auto theta = 0.5;
+  auto predecessors = arlib::multi_predecessor_map<Vertex>{};
+
+  REQUIRE_THROWS_AS(
+      arlib::onepass_plus(G, predecessors, s, t, k, theta, arlib::timer{1ms}),
+      arlib::terminator_stop_error);
 }

--- a/test/include/test_onepass_plus.cpp
+++ b/test/include/test_onepass_plus.cpp
@@ -157,6 +157,6 @@ TEST_CASE("OnePass+ times-out on large graph", "[onepassplus]") {
   auto predecessors = arlib::multi_predecessor_map<Vertex>{};
 
   REQUIRE_THROWS_AS(
-      arlib::onepass_plus(G, predecessors, s, t, k, theta, arlib::timer{1ms}),
+      arlib::onepass_plus(G, predecessors, s, t, k, theta, arlib::timer{1us}),
       arlib::terminator_stop_error);
 }

--- a/test/include/test_penalty.cpp
+++ b/test/include/test_penalty.cpp
@@ -297,6 +297,6 @@ TEST_CASE("Penalty times-out on large graph", "[penalty]") {
   REQUIRE_THROWS_AS(arlib::penalty(G, predecessors, s, t, k, theta, p, r,
                                    max_nb_updates, max_nb_steps,
                                    arlib::routing_kernels::astar,
-                                   arlib::timer{1ms}),
+                                   arlib::timer{1us}),
                     arlib::terminator_stop_error);
 }

--- a/test/include/test_penalty.cpp
+++ b/test/include/test_penalty.cpp
@@ -1,8 +1,5 @@
 #include "catch.hpp"
 
-#include "test_types.hpp"
-#include "utils.hpp"
-
 #include <boost/graph/graph_concepts.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
@@ -11,12 +8,17 @@
 #include <arlib/details/penalty_impl.hpp>
 #include <arlib/graph_utils.hpp>
 #include <arlib/penalty.hpp>
+#include <arlib/terminators.hpp>
 #include <arlib/routing_kernels/types.hpp>
+
+#include "test_types.hpp"
+#include "cittastudi_graph.hpp"
+#include "utils.hpp"
 
 #include <experimental/filesystem>
 #include <memory>
 #include <string>
-
+#include <chrono>
 #include <string_view>
 
 using namespace arlib::test;
@@ -275,4 +277,26 @@ TEST_CASE("Penalty running with astar returns same result as "
   for (std::size_t i = 0; i < res_paths_uni.size(); ++i) {
     REQUIRE(res_paths_uni[i].length() == res_paths_bi[i].length());
   }
+}
+
+TEST_CASE("Penalty times-out on large graph", "[penalty]") {
+  using namespace boost;
+  using namespace std::chrono_literals;
+
+  auto G = arlib::read_graph_from_string<Graph>(std::string(cittastudi_gr));
+
+  Vertex s = 0, t = 20;
+  auto k = 3;
+  auto theta = 0.5;
+  auto p = 0.1;
+  auto r = 0.1;
+  auto max_nb_updates = 10;
+  auto max_nb_steps = 10000;
+  auto predecessors = arlib::multi_predecessor_map<Vertex>{};
+
+  REQUIRE_THROWS_AS(arlib::penalty(G, predecessors, s, t, k, theta, p, r,
+                                   max_nb_updates, max_nb_steps,
+                                   arlib::routing_kernels::astar,
+                                   arlib::timer{1ms}),
+                    arlib::terminator_stop_error);
 }

--- a/test/include/test_reorder_buffer.cpp
+++ b/test/include/test_reorder_buffer.cpp
@@ -1,13 +1,13 @@
 #include "catch.hpp"
 
+#include <arlib/graph_types.hpp>
+#include <arlib/penalty.hpp>
+#include <arlib/reorder_buffer.hpp>
+#include <arlib/graph_utils.hpp>
+
 #include "cittastudi_graph.hpp"
 #include "test_types.hpp"
 #include "utils.hpp"
-
-#include <arlib/graph_types.hpp>
-#include <arlib/graph_utils.hpp>
-#include <arlib/penalty.hpp>
-#include <arlib/reorder_buffer.hpp>
 
 #include <chrono>
 #include <random>
@@ -56,15 +56,15 @@ TEST_CASE(
   // Sort on similarity thresholds
   arlib::ReorderBuffer::by_relative_similarity(G, paths.begin(), paths.end(), 5,
                                                0.5);
-  for (std::size_t i = 1; i < paths.size(); ++i) {
-    std::cout << "[Path " << i << "]\n";
-    for (std::size_t j = 0; j < i; ++j) {
-      std::cout << "  Similarity with path " << j << ": "
-                << arlib::details::compute_similarity(
-                       paths[i], paths[j], get(boost::edge_weight, paths[j]))
-                << "\n";
-    }
-  }
+  // for (std::size_t i = 1; i < paths.size(); ++i) {
+  //   std::cout << "[Path " << i << "]\n";
+  //   for (std::size_t j = 0; j < i; ++j) {
+  //     std::cout << "  Similarity with path " << j << ": "
+  //               << arlib::details::compute_similarity(
+  //                      paths[i], paths[j], get(boost::edge_weight, paths[j]))
+  //               << "\n";
+  //   }
+  // }
 }
 
 TEST_CASE("Penalty+Reordering runs faster than Plain Penalty") {


### PR DESCRIPTION
Alternative routing library now support **an (optional) terminator** object parameter to terminate the algorithm execution sooner if some conditions are met. The rationale behind this is simple: alternative routing algorithms are very expensive and execution might take very long time on graphs with complex topology or big number of edges. Therefore, a user might not be anymore interested in a solution if too much time is passed. Now it is possible to register a Terminator that will be queried periodically to check if the execution should end.

**Moreover**, this PR removes graph_utils from AR algorithm depencencies, which was highly unintended.